### PR TITLE
Ensure .wav and .flac files are treated as binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 * text eol=crlf
+*.wav binary
+*.flac binary


### PR DESCRIPTION
When I download this repo:
https://github.com/sfzinstruments/karoryfer.black-and-green-guitars

via command line or download button, I get distorted .wav files, however If I download a sample directly it sounds fine e.g.
https://github.com/sfzinstruments/karoryfer.black-and-green-guitars/blob/main/Samples/black/btb/btb_gb5_rr2.wav

I found someone with a similar issue:
https://stackoverflow.com/questions/71295453/can-i-prevent-git-from-compressing-my-audio-files

If `.gitattributes` file contains `* text eol=lf` then
Since git treats the audio files as text, then this formatting is applied. And this explains why they sound "broken" afterwards. 